### PR TITLE
Migrate to use cowtools v1.0

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -15,9 +15,9 @@ config = {
         #Which XRootD server to use
         #For Wisconsin, options are "xcache" for the full server, or
         #"xcache01" - "xcache05" for the individual disks
-        "XROOTD_CHOICE": "xcache",
+        "XROOTD_CHOICE": "cmsxrootd.fnal.gov",
         #If None, there is no max
-        "N_FILES_MAX_PER_SAMPLE": 2,
+        "N_FILES_MAX_PER_SAMPLE": None,
         "N_CHUNKS_MAX_PER_FILE": None,
         #Number of seconds before giving up on file reading
         "TIMEOUT": 300,

--- a/xcache_test.py
+++ b/xcache_test.py
@@ -30,7 +30,7 @@ def get_client():
     if not utils.config["benchmarking"]["USE_HTC"]:
         return Client()
     if utils.config["global"]["AF"] == "Wisconsin":
-        client = cowtools.jobqueue,GetCondorClient(
+        client = cowtools.jobqueue.GetCondorClient(
             max_workers=utils.config["benchmarking"]["MAX_WORKERS"],
             memory="4 GB",
             disk="2 GB"
@@ -104,10 +104,11 @@ def main():
         print('Finished computing signal outputs')
 
     exec_time = time.monotonic() - t0
+
+    if utils.config["benchmarking"]["USE_HTC"]:
+        client.shutdown()
     
-    client.shutdown()
-    
-    print(f"\nexecution with XCache took {exec_time:.2f} seconds")
+    print(f"\nexecution took {exec_time:.2f} seconds")
     creports["TotalTime"] = exec_time
 
     with open(f"{rep_fname}.pkl", "wb") as f:


### PR DESCRIPTION
- Switch from `import cowtools` to `import cowtools.jobqueue` to use cowtools v1.0
- Update processor b-tagging score to use one available in Run 3
- Minor tweaks to `test_processor.py` for presentation purposes